### PR TITLE
Specify build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    'numpy',
+    'setuptools'
+]


### PR DESCRIPTION
This PR specifies that building `pymatsolver` requires `numpy` and `setuptools`. This allows the use of `uv` to compile requirements in `machine-prospector`